### PR TITLE
Initial version of working Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+node_modules/
+v6/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /.pnp
 .pnp.js
 
+# yarn cache
+/v6
+
 # testing
 /coverage
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM nikolaik/python-nodejs:python3.8-nodejs12
+
+LABEL MAINTAINER="James Richards <heiho1@yahoo.com>"
+EXPOSE 3000/tcp
+
+# Copy cache contents (if any) from local machine
+# ADD .yarn-cache.tgz /
+
+# Install packages
+ADD package.json yarn.lock /tmp/
+RUN cd /tmp && yarn
+RUN mkdir -p /opt/app && cd /opt/app && ln -s /tmp/node_modules
+
+# Copy the code
+ADD . /opt/app
+WORKDIR /opt/app
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ The following code can be run locally by running the following two commands.
 2. `yarn start`
 
 on the root level of the directory.
+
+## Docker 
+The code can also be run using the Dockerfile.  First you must install Docker for your host operating system from the resources at [Docker|https://www.docker.com/].
+
+With docker running you can build an image and run a container from that image:
+
+0. Using a command line terminal, change into the KyberVirtualHackathon root directory
+1. `docker build -t defistrategies .`
+2. "docker run -p 3000:3000 defistrategies:latest `cd /opt/app; yarn start`"
+3. Execute `docker stop` in another terminal to stop the docker container.
+
+At this point the react server will start and you will be able to access http://localhost:3000 in any browser on your host operating system.


### PR DESCRIPTION
Added a simple Docker that works after testing several different possible dockers.  Note that Node v 13 seems to have build problems so the docker is using Node v 12.  I also tested locally against Node v 11 and that also seems to work, at least on OS X.  This is a bulkier Docker in that it is a full Linux with python 3.8 installed but it simplifies the initial dockerization.  Image size is around 500MB which is larger than an alpine image would be but probably significantly easier to manage.